### PR TITLE
Added Tor event descriptions

### DIFF
--- a/stem/response/events.py
+++ b/stem/response/events.py
@@ -8,6 +8,7 @@ import time
 import stem
 import stem.control
 import stem.descriptor.router_status_entry
+import stem.manual
 import stem.response
 import stem.version
 
@@ -1319,6 +1320,17 @@ def _parse_cell_type_mapping(mapping):
     results[key] = int(value)
 
   return results
+
+
+def event_summary(event):
+  """
+  Provides a description for Tor events.
+
+  :param str event: the event for which a description is needed
+
+  :returns: str The event description
+  """
+  return stem.manual._config().get('event.description.%s' % event.lower(), '')
 
 
 EVENT_TYPE_TO_CLASS = {

--- a/stem/settings.cfg
+++ b/stem/settings.cfg
@@ -5,6 +5,10 @@
 #   * manual.important   Most commonly used configuration options.
 #   * manual.summary     Short summary describing the option.
 #
+# Tor and Nyx event descriptions...
+#
+#   * event.description  Descriptions for the events.
+#
 ################################################################################
 
 manual.important BandwidthRate
@@ -361,4 +365,35 @@ manual.summary.TestingAuthKeyLifetime Duration for our ed25519 signing key
 manual.summary.TestingLinkKeySlop Time before expiration that we replace our ed25519 link key
 manual.summary.TestingAuthKeySlop Time before expiration that we replace our ed25519 authentication key
 manual.summary.TestingSigningKeySlop Time before expiration that we replace our ed25519 signing key
+
+event.description.debug Tor debug logging event.
+event.description.info Tor info logging event.
+event.description.notice Tor notice logging event.
+event.description.warn Tor warn logging event.
+event.description.err Tor error logging event.
+event.description.nyx_debug Nyx debug logging event.
+event.description.nyx_info Nyx info logging event.
+event.description.nyx_notice Nyx notice logging event.
+event.description.nyx_warn Nyx warn logging event.
+event.description.nyx_error Nyx error logging event.
+event.description.circ Indicates that a circuit has changed.
+event.description.circ_minor Provides information about minor changes in our circuits.
+event.description.stream Indicates that a stream has changed.
+event.description.orconn Indicates a change in a relay connection.
+event.description.bw Event emitted every second with the bytes sent and received by tor.
+event.description.newdesc Indicates that a new descriptor is available.
+event.description.addrmap Indicates a new address mapping.
+event.description.authdir_newdescs Indicates that we just received new descriptors specific to directory authorities.
+event.description.descchanged Indicates that our descriptor has changed.
+event.description.ns Event for when our copy of the consensus has changed.
+event.description.status_general Notification of a change in tor's state.
+event.description.status_client Notification of a change in tor's state.
+event.description.status_server Notification of a change in tor's state.
+event.description.guard Indicates that our guard relays have changed.
+event.description.stream_bw Event with the bytes sent and received by tor since the last such event on this stream.
+event.description.clients_seen Periodic event on bridge relays that provide a summary of our users.
+event.description.newconsensus Event for when we have a new consensus.
+event.description.buildtimeout_set Indicates the timeout value for a circuit has changed.
+event.description.signal Indicates that tor has received and acted upon a signal being sent to the process.
+event.description.conf_changed Indicates that our configuration changed, either in a response to a SETCONF or RELOAD signal.
 


### PR DESCRIPTION
The Tor event descriptions are read from `settings.cfg` and returned from the `event_summary` method.
